### PR TITLE
Direct link to VS Code extension

### DIFF
--- a/Windows10.md
+++ b/Windows10.md
@@ -117,10 +117,8 @@ If this succeeds, we're still on track.
 
 Finally, to set up your development environment:
 * Download and install Visual Studio Code from https://code.visualstudio.com/download 
-* Open Visual Studio Code
-* Navigate to the "Extensions" tab
-* Type "Haskell" in the search bar
-* Select the "Haskell" extension. It should be the top option. This will automatically install the language server and provide intellisense.
+* Install the Haskell extension: https://marketplace.visualstudio.com/items?itemName=haskell.haskell
+  * Alternatively, open the Extensions tab in VS Code and search for "haskell.haskell", the extension's ID.
 
 Create a new project by executing the following command in a new folder called Test:
 


### PR DESCRIPTION
Directly link to the correct Haskell VS Code extension so the guide doesn't rely on consistent ordering of extension search results in VS Code. Give installing from within VS Code with the extension's ID `haskell.haskell` as an alternative.